### PR TITLE
Add arm64-v8a to abi filters

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,7 +28,7 @@ android {
                 // (at least for the default floating point implementation) and ARM64 supports
                 // also armeabi-v7a binaries natively, so let's use those, which should be more
                 // efficient.
-                abiFilters "armeabi-v7a", "x86", "x86_64"
+                abiFilters "armeabi-v7a", "arm64-v8a", "x86", "x86_64"
             }
         }
     }


### PR DESCRIPTION
Since Google play is pushing Android apps to use ARM-64 CPU architecture in native libraries, I added this abi filter to have it in the next release of this library.

This pull request will close #10 