### PR TITLE
Support for ARM64

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,11 +24,7 @@ android {
         consumerProguardFiles 'proguard-rules.pro'
         externalNativeBuild {
             ndkBuild {
-                // We don't build for arm64-v8a for now, because ASM optimizations do not compile
-                // (at least for the default floating point implementation) and ARM64 supports
-                // also armeabi-v7a binaries natively, so let's use those, which should be more
-                // efficient.
-                abiFilters "armeabi-v7a", "x86", "x86_64"
+		abiFilters "armeabi-v7a", "arm64-v8a", "x86", "x86_64"
             }
         }
     }


### PR DESCRIPTION
As per Google: "Starting August 1, 2019, our apps published on Google Play will need to support 64-bit architectures. 64-bit CPUs deliver faster, richer experiences for your users. Adding a 64-bit version of your app provides performance improvements."

The current repo builds for x86-64 but not for ARM64. This PR enables building for ARM64. It has been tested to build correctly.